### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Multi-timer for CCDC.
 
 ### Dependencies
 
-Make sure the following depencies are installed:
+Make sure the following dependencies are installed:
 
 1. **npm** and **node**: [installation](https://nodejs.org/en/download/)
 


### PR DESCRIPTION
## Summary
- fix spelling of "dependencies" in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9ab3b0ec832d8341599908e871fa